### PR TITLE
Add Fritzsche et al. papers from AAAI2026 

### DIFF
--- a/crossref-short.bib
+++ b/crossref-short.bib
@@ -219,6 +219,12 @@
   year =         "2025"
 }
 
+@Proceedings{aaai2026,
+  title =        "Proc.\ {AAAI} 2026",
+  booktitle =    "Proc.\ {AAAI} 2026",
+  year =         "2026"
+}
+
 @Proceedings{aamas2010,
   title =        "Proc.\ AAMAS 2010",
   booktitle =    "Proc.\ AAMAS 2010",

--- a/crossref.bib
+++ b/crossref.bib
@@ -353,6 +353,16 @@
   year =         "2025"
 }
 
+@Proceedings{aaai2026,
+  editor =       "Chad Jenkins and Matthew Taylor",
+  title =        "Proceedings of the Fortieth {AAAI} Conference on
+                  Artificial Intelligence ({AAAI} 2026)",
+  booktitle =    "Proceedings of the Fortieth {AAAI} Conference on
+                  Artificial Intelligence ({AAAI} 2026)",
+  publisher =    "{AAAI} Press",
+  year =         "2026"
+}
+
 @Proceedings{aamas2010,
   editor =       "W. van der Hoek and G.A. Kaminka and Y. Lesp{\'e}rance and M. Luck and S. Sen",
   title =        "Proceedings of the 9th International Conference

--- a/literatur.bib
+++ b/literatur.bib
@@ -6529,6 +6529,20 @@
   pages =        "251--281"
 }
 
+# TODO(Markus): Add pages
+@InProceedings{fritzsche-et-al-aaai2026a,
+  author =       "Markus Fritzsche and Elliot Gestrin and Jendrik Seipp",
+  title =        "Symmetry-Aware Transformer Training for Automated Planning",
+  crossref =     "aaai2026"
+}
+
+# TODO(Markus): Add pages
+@InProceedings{fritzsche-et-al-aaai2026b,
+  author =       "Markus Fritzsche and Daniel Gnad and Mikhail Gruntov and Alexander Shleyfman",
+  title =        "Managing Infinite Abstractions in Numeric Pattern Database Heuristics",
+  crossref =     "aaai2026"
+}
+
 @InProceedings{froleyks-et-al-cav2025,
   author =       "Nils Froleyks and Emily Yu and Mathias Preiner and
                   Armin Biere and Keijo Heljanko",


### PR DESCRIPTION
Add the two paper entries with titles: 
"Symmetry-Aware Transformer Training for Automated Planning"

and 

"Managing Infinite Abstractions in Numeric Pattern Database Heuristics". 
