### PR TITLE
Add joergensen-et-al-icaps2026wshsdip{a,b} entries

### DIFF
--- a/crossref-short.bib
+++ b/crossref-short.bib
@@ -1208,6 +1208,14 @@
   year =         "2026"
 }
 
+@Proceedings{icaps2026wshsdip,
+  title =        "ICAPS Workshop on Heuristics and Search for
+                  Domain-independent Planning",
+  booktitle =    "ICAPS Workshop on Heuristics and Search for
+                  Domain-independent Planning",
+  year =         "2026"
+}
+
 @Proceedings{icaps2026wsprl,
   title =        "ICAPS Workshop on Bridging the Gap Between AI
                   Planning and Reinforcement Learning (PRL)",

--- a/crossref.bib
+++ b/crossref.bib
@@ -1854,6 +1854,14 @@
   year =         "2026"
 }
 
+@Proceedings{icaps2026wshsdip,
+  title =        "ICAPS 2026 Workshop on Heuristics and Search
+                  for Domain-independent Planning (HSDIP)",
+  booktitle =    "ICAPS 2026 Workshop on Heuristics and Search
+                  for Domain-independent Planning (HSDIP)",
+  year =         "2026"
+}
+
 @Proceedings{icaps2026wsprl,
   title =        "ICAPS 2026 Workshop on Bridging the Gap Between AI
                   Planning and Reinforcement Learning (PRL)",

--- a/literatur.bib
+++ b/literatur.bib
@@ -9967,6 +9967,18 @@
   crossref =     "icaart2025"
 }
 
+@InProceedings{joergensen-et-al-icaps2026wshsdipa,
+  author =       "Oliver Joergensen and Dominik Drexler and Jendrik Seipp",
+  title =        "Distributed Parallel Datalog in Automated Planning",
+  crossref =     "icaps2026wshsdip"
+}
+
+@InProceedings{joergensen-et-al-icaps2026wshsdipb,
+  author =       "Oliver Joergensen and Dominik Drexler and Jendrik Seipp",
+  title =        "Dynamic Tree Databases in Automated Planning",
+  crossref =     "icaps2026wshsdip"
+}
+
 @InProceedings{john-koopmann-ecai2024,
   author =       "Tobias John and Patrick Koopmann",
   title =        "Planning with {OWL-DL} Ontologies",


### PR DESCRIPTION
Add two ICAPS 2026 HSDIP workshop papers by Joergensen, Drexler and Seipp:

- `joergensen-et-al-icaps2026wshsdipa` — Distributed Parallel Datalog in Automated Planning
- `joergensen-et-al-icaps2026wshsdipb` — Dynamic Tree Databases in Automated Planning

Also adds the `icaps2026wshsdip` proceedings entry to `crossref.bib` and `crossref-short.bib`.

`./tests/format-bib.sh` made no changes; `./tests/run-tests.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)